### PR TITLE
Update entrypoint command in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - MISP_BASEURL=${MISP_BASEURL}
       - POSTFIX_RELAY_HOST=${POSTFIX_RELAY_HOST}
       - TIMEZONE=${TIMEZONE}
-    entrypoint: "wait-for-it.sh -t 0 -h db -p 3306 -- /run.sh"
+    entrypoint: "wait-for-it.sh -t 0 -h ${MYSQL_DATABASE} -p 3306 -- /run.sh"
 
   db:
     container_name: misp_db


### PR DESCRIPTION
Change the -h parameter to use the database name specified in the .env file. I was trying to run the web and database containers on different servers, and this entry point check was not allow the web service to start since the db was running elsewhere. 